### PR TITLE
didnt do it right

### DIFF
--- a/frontend/src/fixtures/diningCommonsFixtures.js
+++ b/frontend/src/fixtures/diningCommonsFixtures.js
@@ -5,8 +5,6 @@ const diningCommonsFixtures = {
     hasSackMeal: false,
     hasTakeoutMeal: false,
     hasDiningCam: true,
-    latitude: 34.409953,
-    longitude: -119.85277,
   },
   oneCommonsDiningCamFalse: {
     name: "Carrillo",
@@ -14,8 +12,6 @@ const diningCommonsFixtures = {
     hasSackMeal: false,
     hasTakeoutMeal: false,
     hasDiningCam: false,
-    latitude: 34.409953,
-    longitude: -119.85277,
   },
   fourCommons: [
     {
@@ -24,8 +20,6 @@ const diningCommonsFixtures = {
       hasSackMeal: false,
       hasTakeoutMeal: false,
       hasDiningCam: true,
-      latitude: 34.409953,
-      longitude: -119.85277,
     },
     {
       name: "De La Guerra",
@@ -33,8 +27,6 @@ const diningCommonsFixtures = {
       hasSackMeal: false,
       hasTakeoutMeal: false,
       hasDiningCam: true,
-      latitude: 34.409811,
-      longitude: -119.845026,
     },
     {
       name: "Ortega",
@@ -42,8 +34,6 @@ const diningCommonsFixtures = {
       hasSackMeal: true,
       hasTakeoutMeal: true,
       hasDiningCam: true,
-      latitude: 34.410987,
-      longitude: -119.84709,
     },
     {
       name: "Portola",
@@ -51,8 +41,6 @@ const diningCommonsFixtures = {
       hasSackMeal: true,
       hasTakeoutMeal: true,
       hasDiningCam: true,
-      latitude: 34.417723,
-      longitude: -119.867427,
     },
   ],
 };

--- a/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
@@ -33,14 +33,6 @@ export default function DiningCommonsTable({ commons, date }) {
       accessor: "hasTakeoutMeal",
       Cell: ({ value }) => (value ? "✅" : "❌"),
     },
-    {
-      Header: "Latitude",
-      accessor: "latitude",
-    },
-    {
-      Header: "Longitude",
-      accessor: "longitude",
-    },
   ];
 
   const displayedColumns = columns;

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
@@ -20,8 +20,6 @@ describe("DiningCommonsTable tests", () => {
     "Has Dining Cam",
     "Has Sack Meal",
     "Has Takeout Meal",
-    "Latitude",
-    "Longitude",
   ];
   const expectedFields = [
     "code",
@@ -29,8 +27,6 @@ describe("DiningCommonsTable tests", () => {
     "hasDiningCam",
     "hasSackMeal",
     "hasTakeoutMeal",
-    "latitude",
-    "longitude",
   ];
   const testId = "DiningCommonsTable";
   const date = new Date("2025-03-11").toISOString().split("T")[0];
@@ -216,8 +212,6 @@ describe("DiningCommonsTable tests", () => {
       "Has Dining Cam",
       "Has Sack Meal",
       "Has Takeout Meal",
-      "Latitude",
-      "Longitude",
     ];
     const expectedFields = [
       "code",
@@ -225,8 +219,6 @@ describe("DiningCommonsTable tests", () => {
       "hasDiningCam",
       "hasSackMeal",
       "hasTakeoutMeal",
-      "latitude",
-      "longitude",
     ];
     const testId = "DiningCommonsTable";
 
@@ -266,8 +258,6 @@ describe("DiningCommonsTable tests", () => {
       "Has Dining Cam",
       "Has Sack Meal",
       "Has Takeout Meal",
-      "Latitude",
-      "Longitude",
     ];
     const expectedFields = [
       "code",
@@ -275,8 +265,6 @@ describe("DiningCommonsTable tests", () => {
       "hasDiningCam",
       "hasSackMeal",
       "hasTakeoutMeal",
-      "latitude",
-      "longitude",
     ];
     const testId = "DiningCommonsTable";
 

--- a/src/main/java/edu/ucsb/cs156/dining/models/DiningCommons.java
+++ b/src/main/java/edu/ucsb/cs156/dining/models/DiningCommons.java
@@ -1,13 +1,11 @@
 package edu.ucsb.cs156.dining.models;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import java.util.Map;
 
-import static java.lang.Double.parseDouble;
 
 @Builder
 @Data
@@ -19,16 +17,9 @@ public class DiningCommons {
   private Boolean hasDiningCam;
   private Boolean hasSackMeal;
   private Boolean hasTakeOutMeal;
-  private Double latitude;
-  private Double longitude;
 
 
-  //Found this on Baeldung for unpacking nested json properties: https://www.baeldung.com/jackson-nested-values
-  @JsonProperty("location")
-  private void unpackedNested(Map<String,Object> location){
-    this.latitude = (Double) location.get("latitude");
-    this.longitude = (Double) location.get("longitude");
-  }
+
 
   public static final String SAMPLE_CARRILLO =
       """
@@ -38,8 +29,6 @@ public class DiningCommons {
               "hasDiningCam": true,
               "hasSackMeal": false,
               "hasTakeOutMeal" : false,
-              "latitude" : null,
-              "longitude" : null
           }
       """;
 }

--- a/src/test/java/edu/ucsb/cs156/dining/services/DiningCommonsServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/services/DiningCommonsServiceTests.java
@@ -40,8 +40,6 @@ class DiningCommonsServiceTests {
   private static final Boolean HASDININGCAM = false;
   private static final Boolean HASSACKMEAL = false;
   private static final Boolean HASTAKEOUTMEAL = false;
-  private static final Double LATITUDE = 1.0;
-  private static final Double LONGITUDE = 2.0;
 
   @Test
   void get_returns_a_list_of_commons() throws Exception {
@@ -58,10 +56,6 @@ class DiningCommonsServiceTests {
               \"hasDiningCam\": \"%s\",
               \"hasSackMeal\": \"%s\",
               \"hasTakeOutMeal\": \"%s\",
-              \"location\":{
-                \"longitude\": %s,
-                \"latitude\": %s
-              }
             }
             ]
             """,
@@ -69,9 +63,7 @@ class DiningCommonsServiceTests {
             CODE,
             HASDININGCAM,
             HASSACKMEAL,
-            HASTAKEOUTMEAL,
-            LONGITUDE,
-            LATITUDE);
+            HASTAKEOUTMEAL);
 
     DiningCommons expectedCommons =
         DiningCommons.builder()
@@ -80,8 +72,6 @@ class DiningCommonsServiceTests {
             .hasDiningCam(HASDININGCAM)
             .hasSackMeal(HASSACKMEAL)
             .hasTakeOutMeal(HASTAKEOUTMEAL)
-            .latitude(LATITUDE)
-            .longitude(LONGITUDE)
             .build();
 
     this.mockRestServiceServer


### PR DESCRIPTION
Closes #14 

In this PR, we removed the longitude and latitude from the Dining Commons table because they are not necessary to have on there.


BEFORE:
![image](https://github.com/user-attachments/assets/1e4189d8-a054-4f9a-b0fe-752acc5f7f23)

AFTER:
![image](https://github.com/user-attachments/assets/70e68e6d-3953-4748-8129-e290a415228f)

You can see these changes by running localhost and checking my personal dev deployment at: https://dining-tn.dokku-06.cs.ucsb.edu/
