### PR TITLE
Timothy - Removed Longitude and Latitude

### DIFF
--- a/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
@@ -33,14 +33,6 @@ export default function DiningCommonsTable({ commons, date }) {
       accessor: "hasTakeoutMeal",
       Cell: ({ value }) => (value ? "✅" : "❌"),
     },
-    {
-      Header: "Latitude",
-      accessor: "latitude",
-    },
-    {
-      Header: "Longitude",
-      accessor: "longitude",
-    },
   ];
 
   const displayedColumns = columns;

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
@@ -20,8 +20,6 @@ describe("DiningCommonsTable tests", () => {
     "Has Dining Cam",
     "Has Sack Meal",
     "Has Takeout Meal",
-    "Latitude",
-    "Longitude",
   ];
   const expectedFields = [
     "code",
@@ -29,8 +27,6 @@ describe("DiningCommonsTable tests", () => {
     "hasDiningCam",
     "hasSackMeal",
     "hasTakeoutMeal",
-    "latitude",
-    "longitude",
   ];
   const testId = "DiningCommonsTable";
   const date = new Date("2025-03-11").toISOString().split("T")[0];
@@ -216,8 +212,6 @@ describe("DiningCommonsTable tests", () => {
       "Has Dining Cam",
       "Has Sack Meal",
       "Has Takeout Meal",
-      "Latitude",
-      "Longitude",
     ];
     const expectedFields = [
       "code",
@@ -225,8 +219,6 @@ describe("DiningCommonsTable tests", () => {
       "hasDiningCam",
       "hasSackMeal",
       "hasTakeoutMeal",
-      "latitude",
-      "longitude",
     ];
     const testId = "DiningCommonsTable";
 
@@ -266,8 +258,6 @@ describe("DiningCommonsTable tests", () => {
       "Has Dining Cam",
       "Has Sack Meal",
       "Has Takeout Meal",
-      "Latitude",
-      "Longitude",
     ];
     const expectedFields = [
       "code",
@@ -275,8 +265,6 @@ describe("DiningCommonsTable tests", () => {
       "hasDiningCam",
       "hasSackMeal",
       "hasTakeoutMeal",
-      "latitude",
-      "longitude",
     ];
     const testId = "DiningCommonsTable";
 


### PR DESCRIPTION
Closes https://github.com/ucsb-cs156-s25/proj-dining-s25-06/issues/14

In this PR, we removed the longitude and latitude from the Dining Commons table because they are not necessary to have on there.

BEFORE:
![image](https://github.com/user-attachments/assets/c5a5615c-f893-40a2-aac9-54dffda0e8f4)

AFTER:
![image](https://github.com/user-attachments/assets/96697438-a0c8-4c61-b1dd-81069157fc59)

You can see these changes by running localhost and checking my personal dev deployment at: https://dining-tn.dokku-06.cs.ucsb.edu/