### PR TITLE
Timothy - auto approve reviews for reviewers who put no comments

### DIFF
--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
@@ -102,18 +102,31 @@ public class ReviewController extends ApiController {
         Review review = new Review();
         review.setDateItemServed(dateItemServed);
 
-        // Ensures content of truly empty and sets to null if so
-        if ((!reviewerComments.trim().isEmpty())) {
-            review.setReviewerComments(reviewerComments);
+        boolean isEmpty = false;
+        String commentsToSet;
+        ModerationStatus statusToSet;
+        if ((reviewerComments == null || reviewerComments.trim().isEmpty())) {
+            isEmpty = true;
         }
-
+        if (isEmpty) {
+            commentsToSet = null;
+        } else {
+            commentsToSet = reviewerComments;
+        }
+        if (isEmpty) {
+            statusToSet = ModerationStatus.APPROVED;
+        } else {
+            statusToSet = ModerationStatus.AWAITING_REVIEW;
+        }
+        review.setReviewerComments(commentsToSet);
+        review.setStatus(statusToSet);
         // Ensure user inputs rating 1-5
         if (itemsStars < 1 || itemsStars > 5) {
             throw new IllegalArgumentException("Items stars must be between 1 and 5.");
         }
 
         review.setItemsStars(itemsStars);
-
+        
         MenuItem reviewedItem = menuItemRepository.findById(itemId).orElseThrow(
                 () -> new EntityNotFoundException(MenuItem.class, itemId)
         );
@@ -160,13 +173,14 @@ public class ReviewController extends ApiController {
 
         if (incoming.getReviewerComments() != null &&!incoming.getReviewerComments().trim().isEmpty()) {
             oldReview.setReviewerComments(incoming.getReviewerComments());
+            oldReview.setStatus(ModerationStatus.AWAITING_REVIEW);
         }else{
             oldReview.setReviewerComments(null);
+            oldReview.setStatus(ModerationStatus.APPROVED);
         }
 
         oldReview.setDateItemServed(incoming.getDateItemServed());
 
-        oldReview.setStatus(ModerationStatus.AWAITING_REVIEW);
         oldReview.setModeratorComments(null);
 
         Review review = reviewRepository.save(oldReview);

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
@@ -213,4 +213,19 @@ public class ReviewController extends ApiController {
         Iterable<Review> reviewsList = reviewRepository.findByStatus(ModerationStatus.AWAITING_REVIEW);
         return reviewsList;
     }
+    @Operation(summary = "Get a specific single review ID")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/get")
+    public Review getReviewByID(@Parameter Long id) {
+        Review review = reviewRepository.findById(id).orElseThrow(
+                () -> new EntityNotFoundException(Review.class, id)
+        );
+
+        User current = getCurrentUser().getUser();
+        if(current.getId() != review.getReviewer().getId() && !current.getAdmin()) {
+            throw new AccessDeniedException("Only user who made this review or admin can get id");
+        }
+        return review;
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsController.java
@@ -19,6 +19,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.http.ResponseEntity;
@@ -67,5 +68,15 @@ public class UCSBDiningMenuItemsController extends ApiController {
     }
 
     return ResponseEntity.ok().body(menuitems);
+  }
+  @Operation(summary = "Get a single specific menu item by id")
+  @GetMapping(value = "/menuitem", produces = "application/json")
+  public ResponseEntity<MenuItem> getMenuItemById(
+      @Parameter(description = "ID of the menu item") @RequestParam Long id
+  ) {
+    MenuItem menuItem = menuItemRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException(MenuItem.class, id));
+
+    return ResponseEntity.ok().body(menuItem);
   }
 }

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
@@ -991,6 +991,102 @@ public class ReviewControllerTests extends ControllerTestCase {
         assertEquals(expectedJson,responseJson);
     }
 
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void wrong_user_cannot_get_id() throws Exception{
+        User user2 = User.builder().id(2L).build();
 
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user2)
+                .status(ModerationStatus.APPROVED)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+        MvcResult response = mockMvc.perform(get("/api/reviews/get")
+                .param("id", "1")
+                .with(csrf())).andExpect(status().isForbidden()).andReturn();
+    }
+
+    @WithMockUser(roles = {"ADMIN","USER"})
+    @Test
+    public void admin_can_get_id() throws Exception{
+        User user2 = User.builder().id(2L).build();
+
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user2)
+                .status(ModerationStatus.APPROVED)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+        MvcResult response = mockMvc.perform(get("/api/reviews/get")
+                .param("id", "1")
+                .with(csrf())).andExpect(status().isOk()).andReturn();
+        verify(reviewRepository, times(1)).findById(eq(1L));
+
+        String expectedJson = mapper.writeValueAsString(review1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void user_can_get_id() throws Exception{
+        User user1 = currentUserService.getUser();
+
+        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+
+        Review review1 = Review.builder()
+                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                .reviewer(user1)
+                .status(ModerationStatus.APPROVED)
+                .item(menuItem1)
+                .id(1L)
+                .build();
+
+
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.of(review1));
+
+        MvcResult response = mockMvc.perform(get("/api/reviews/get")
+                .param("id", "1")
+                .with(csrf())).andExpect(status().isOk()).andReturn();
+        verify(reviewRepository, times(1)).findById(eq(1L));
+
+        String expectedJson = mapper.writeValueAsString(review1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void cannot_delete_id_that_does_not_exist() throws Exception{
+        when(reviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+        MvcResult response = mockMvc.perform(get("/api/reviews/get")
+                .param("id", "1")
+                .with(csrf())).andExpect(status().isNotFound()).andReturn();
+
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("Review with id 1 not found", json.get("message"));
+    }
 
 }

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
@@ -249,7 +249,54 @@ public class ReviewControllerTests extends ControllerTestCase {
         
         assertEquals(jsonReview, responseJson);
     }
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void test_null_on_creating_new_review() throws Exception {
 
+        // Arrange
+        LocalDateTime now = LocalDateTime.now();
+
+        User user = currentUserService.getUser();
+        MenuItem menuItem = MenuItem.builder().id(1L).build();
+
+        Review review = Review.builder()
+                .itemsStars(1L)
+                .reviewerComments(null) 
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+                .reviewer(user)
+                .status(ModerationStatus.APPROVED)
+                .item(menuItem)
+                .build();
+
+        Review reviewReturn = Review.builder()
+                .dateCreated(now)
+                .dateEdited(now)
+                .itemsStars(1L)
+                .reviewerComments(null)
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+                .reviewer(user)
+                .status(ModerationStatus.APPROVED)
+                .item(menuItem)
+                .id(0L)
+                .build();
+
+        when(reviewRepository.save(eq(review))).thenReturn(reviewReturn);
+
+        // Act
+        MvcResult response = mockMvc.perform(
+                        post("/api/reviews/post?itemId=1&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
+                                .with(csrf())) 
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String jsonReview = mapper.writeValueAsString(reviewReturn);
+
+        // Assert
+        verify(reviewRepository).save(any(Review.class));
+        String responseJson = response.getResponse().getContentAsString();
+
+        assertEquals(jsonReview, responseJson);
+    }
     @WithMockUser(roles = {"USER"})
     @Test
     public void test_no_string_on_creating_new_review() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
@@ -53,6 +53,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -216,7 +217,7 @@ public class ReviewControllerTests extends ControllerTestCase {
                 .reviewerComments(null)
                 .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
                 .reviewer(user)
-                .status(ModerationStatus.AWAITING_REVIEW)
+                .status(ModerationStatus.APPROVED)
                 .item(menuItem)
                 .build();
 
@@ -227,7 +228,7 @@ public class ReviewControllerTests extends ControllerTestCase {
                 .reviewerComments(null)
                 .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
                 .reviewer(user)
-                .status(ModerationStatus.AWAITING_REVIEW)
+                .status(ModerationStatus.APPROVED)
                 .item(menuItem)
                 .id(0L)
                 .build();
@@ -245,7 +246,7 @@ public class ReviewControllerTests extends ControllerTestCase {
         // Assert
         verify(reviewRepository).save(any(Review.class));
         String responseJson = response.getResponse().getContentAsString();
-
+        
         assertEquals(jsonReview, responseJson);
     }
 
@@ -263,7 +264,7 @@ public class ReviewControllerTests extends ControllerTestCase {
                 .itemsStars(1l)
                 .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
                 .reviewer(user)
-                .status(ModerationStatus.AWAITING_REVIEW)
+                .status(ModerationStatus.APPROVED)
                 .item(menuItem)
                 .build();
 
@@ -273,7 +274,7 @@ public class ReviewControllerTests extends ControllerTestCase {
                 .itemsStars(1l)
                 .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
                 .reviewer(user)
-                .status(ModerationStatus.AWAITING_REVIEW)
+                .status(ModerationStatus.APPROVED)
                 .item(menuItem)
                 .id(0L)
                 .build();
@@ -292,6 +293,51 @@ public class ReviewControllerTests extends ControllerTestCase {
         String reviewJson = mapper.writeValueAsString(reviewReturn);
         assertEquals(responseJson, reviewJson);
 
+    }
+    @WithMockUser(roles = {"USER"})
+    @Test
+    public void test_string_on_creating_new_review() throws Exception {
+
+        // Arrange
+        LocalDateTime now = LocalDateTime.now();
+
+        User user = currentUserService.getUser();
+        MenuItem menuItem = MenuItem.builder().id(1L).build();
+
+        Review review = Review.builder()
+                .itemsStars(1l)
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+                .reviewer(user)
+                .reviewerComments("test")
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem)
+                .build();
+
+        Review reviewReturn = Review.builder()
+                .dateCreated(now)
+                .dateEdited(now)
+                .itemsStars(1l)
+                .reviewerComments("test")
+                .dateItemServed(LocalDateTime.of(2021, 12, 12, 8, 8, 8))
+                .reviewer(user)
+                .status(ModerationStatus.AWAITING_REVIEW)
+                .item(menuItem)
+                .id(0L)
+                .build();
+        when(reviewRepository.save(eq(review))).thenReturn(reviewReturn);
+
+        // Act
+        MvcResult response = mockMvc.perform(
+                        post("/api/reviews/post?itemId=1&reviewerComments=test&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
+                                .with(csrf()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // Assert
+        verify(reviewRepository).save(any(Review.class));
+        String responseJson = response.getResponse().getContentAsString();
+        String reviewJson = mapper.writeValueAsString(reviewReturn);
+        assertEquals(responseJson, reviewJson);
     }
 
     @WithMockUser(roles = {"ADMIN"})
@@ -626,7 +672,7 @@ public class ReviewControllerTests extends ControllerTestCase {
                 .reviewer(user1)
                 .reviewerComments(null)
                 .itemsStars(2L)
-                .status(ModerationStatus.AWAITING_REVIEW)
+                .status(ModerationStatus.APPROVED)
                 .item(menuItem1)
                 .id(1L)
                 .build();
@@ -682,7 +728,7 @@ public class ReviewControllerTests extends ControllerTestCase {
                 .reviewer(user1)
                 .reviewerComments(null)
                 .itemsStars(2L)
-                .status(ModerationStatus.AWAITING_REVIEW)
+                .status(ModerationStatus.APPROVED)
                 .item(menuItem1)
                 .id(1L)
                 .build();

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UCSBDiningMenuItemsControllerTests.java
@@ -103,4 +103,42 @@ public class UCSBDiningMenuItemsControllerTests extends ControllerTestCase {
     Optional<MenuItem> found = menuItemRepository.findByDiningCommonsCodeAndMealCodeAndNameAndStation(diningCommonCode, mealCode, name, station);
     assertTrue(found.isPresent());
   }
+@WithMockUser(roles = { "USER" })
+@Test
+public void test_get_menu_item_by_id_returns_expected_item() throws Exception {
+    // Arrange
+    Long id = 1L;
+    MenuItem menuItem = new MenuItem();
+    menuItem.setId(id);
+    menuItem.setName("Chicken Alfredo");
+    menuItem.setStation("Entrees");
+    menuItem.setDiningCommonsCode("portola");
+    menuItem.setMealCode("lunch");
+
+    when(menuItemRepository.findById(id)).thenReturn(Optional.of(menuItem));
+
+    // Act & Assert
+    mockMvc.perform(get("/api/diningcommons/menuitem")
+            .param("id", id.toString())
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(1))
+            .andExpect(jsonPath("$.name").value("Chicken Alfredo"))
+            .andExpect(jsonPath("$.station").value("Entrees"))
+            .andExpect(jsonPath("$.diningCommonsCode").value("portola"))
+            .andExpect(jsonPath("$.mealCode").value("lunch"));
+}
+@WithMockUser(roles = { "USER" })
+@Test
+public void test_get_menu_item_by_id_when_not_found_returns_404() throws Exception {
+    Long id = 999L;
+    when(menuItemRepository.findById(id)).thenReturn(Optional.empty());
+
+    mockMvc.perform(get("/api/diningcommons/menuitem")
+            .param("id", id.toString())
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.type").value("EntityNotFoundException"))
+            .andExpect(jsonPath("$.message").value("MenuItem with id 999 not found"));
+}
 }


### PR DESCRIPTION
Closes #15 

In this PR, I changed the logic of the post and edit reviews on the swagger such that if the reviewer doesn't put in a comment, it will auto approve. The reason there needs to be moderation approval is to check if the comments are okay to post.. otherwise you wouldn't really need a moderator to check [Because you'd just be putting a star rating, nothing bad could possibly come from that.. right?!]. So if a user edits their comment to have no comment or posts without a comment, their review will be auto approved now. Tweaked the logic of some the test cases to match this as well.

The feature is available to test on localhost or my personal dev dokku:https://dining-tn.dokku-06.cs.ucsb.edu/