### PR TITLE
Timothy - Applied transformation to each of the workflows that uses [OLD CODE] to [NEW CODE]

### DIFF
--- a/.github/workflows/04-gh-pages-redeploy-part-2.yml
+++ b/.github/workflows/04-gh-pages-redeploy-part-2.yml
@@ -123,14 +123,19 @@ jobs:
     - name: a-javadoc Debugging output
       run: | 
         ls -lRt
-    - name: a-javadoc Deploy Javadoc (Main) 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
-      with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: ${{ env.javadoc_dest }} # The folder where we put the files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: javadoc # The folder that we serve our files from
 
+    - name: a-javadoc Deploy Javadoc (Main) 🚀
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
+      with:
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: ${{ env.javadoc_dest }} # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: javadoc # The folder that we serve our files from
     - name: b-chromatic Make directory in case it doesn't exist
       run: mkdir -p ${{ env.chromatic_dest }}
     - name: b-chromatic Download artifact
@@ -142,14 +147,19 @@ jobs:
         path: ${{ env.chromatic_dest }}
         check_artifacts: true
         if_no_artifact_found: error
-    - name: b-chromatic Deploy chromatic (Main) 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
-      with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder:  ${{ env.chromatic_dest}} # The folder where the files come from
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: chromatic # The folder that we serve our files from
 
+    - name: b-chromatic Deploy chromatic (Main) 🚀  
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
+      with:
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder:  ${{ env.chromatic_dest}} # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: chromatic # The folder that we serve our files from
     - name: c-jacoco Make directory in case it doesn't exist
       run: mkdir -p ${{ env.jacoco_dest }}
     - name: c-jacoco Download artifact
@@ -162,14 +172,19 @@ jobs:
         check_artifacts: true
         if_no_artifact_found: error
 
-    - name: c-jacoco Deploy Jacoco (Main) 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
-      with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: ${{ env.jacoco_dest }} # The folder where we put the files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: jacoco # The folder that we serve our files from
 
+    - name: c-jacoco Deploy Jacoco (Main) 🚀   
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
+      with:
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder:  ${{ env.jacoco_dest }} # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: jacoco # The folder that we serve our files from
  
     - name: d-pitest Make directory in case it doesn't exist
       run: mkdir -p ${{ env.pitest_dest }}
@@ -182,14 +197,19 @@ jobs:
         path: ${{ env.pitest_dest }}
         check_artifacts: true
         if_no_artifact_found: error
-    - name:  d-pitest Deploy Pitest (main) 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
-      with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: ${{ env.pitest_dest }} # The folder where we put the files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: pitest # The folder that we serve our files from
 
+    - name: d-pitest Deploy Pitest (main) 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
+      with:
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder:  ${{ env.pitest_dest }} # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: pitest # The folder that we serve our files from
     - name: e-coverage Make directory in case it doesn't exist
       run: mkdir -p ${{ env.coverage_dest }}
     - name: e-coverage Download artifact
@@ -202,14 +222,18 @@ jobs:
         check_artifacts: true
         if_no_artifact_found: error
 
-    - name: e-coverage Deploy Coverage (main) 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+    - name: e-coverage Deploy Coverage (main) 🚀 
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder:  ${{ env.coverage_dest }} # The folder where we put the files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: coverage # The folder that we serve our files from
-
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: ${{ env.coverage_dest }} # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: coverage # The folder that we serve our files from
     - name: f-stryker Make directory in case it doesn't exist
       run: mkdir -p ${{ env.stryker_dest }}
     - name: f-stryker Download artifact
@@ -222,14 +246,19 @@ jobs:
         check_artifacts: true
         if_no_artifact_found: error
 
-    - name: f-stryker Deploy Stryker (main) 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
-      with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder:  ${{ env.stryker_dest }} # The folder where we put the files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: stryker # The folder that we serve our files from
 
+    - name: f-stryker Deploy Stryker (main) 🚀 
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
+      with:
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: ${{ env.stryker_dest }} # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: stryker # The folder that we serve our files from
 
   deploy-doc-for-each-pr:
     name: PR ${{ matrix.value.number }} 
@@ -260,14 +289,19 @@ jobs:
         check_artifacts: true
         if_no_artifact_found: error
 
-    - name: a-javadoc Deploy Javadoc (PR ${{ matrix.value.number }}) 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
-      with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: ${{ env.javadoc_dest  }} # The folder where we put the files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: prs/${{ matrix.value.number }}/javadoc # The folder that we serve our files from
 
+    - name: a-javadoc Deploy Javadoc (PR ${{ matrix.value.number }}) 🚀 
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
+      with:
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: ${{ env.javadoc_dest  }}o # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: prs/${{ matrix.value.number }}/javadoc # The folder that we serve our files from
     - name: b-chromatic Make directory in case it doesn't exist
       run: mkdir -p ${{ env.chromatic_dest }}
 
@@ -281,14 +315,19 @@ jobs:
         check_artifacts: true
         if_no_artifact_found: error
 
-    - name:  b-chromatic Deploy chromatic (PR ${{ matrix.value.number }}) 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+   
+    - name: b-chromatic Deploy chromatic (PR ${{ matrix.value.number }}) 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: ${{ env.chromatic_dest }} # The folder where we put the files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: prs/${{ matrix.value.number }}/chromatic # The folder that we serve our files from
-
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: ${{ env.chromatic_dest }} # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: prs/${{ matrix.value.number }}/chromatic # The folder that we serve our files from
     - name: c-jacoco Make directory in case it doesn't exist
       run: mkdir -p ${{ env.jacoco_dest }}
 
@@ -302,14 +341,19 @@ jobs:
         check_artifacts: true
         if_no_artifact_found: error
 
-    - name: c-jacoco Deploy Jacoco (PR ${{ matrix.value.number }}) 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+ 
+    - name: c-jacoco Deploy Jacoco (PR ${{ matrix.value.number }}) 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: ${{ env.jacoco_dest }} # The folder where we put the files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: prs/${{ matrix.value.number }}/jacoco # The folder that we serve our files from
-
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: ${{ env.jacoco_dest }} # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: prs/${{ matrix.value.number }}/jacoco # The folder that we serve our files from
     - name: d-pitest Make directory in case it doesn't exist
       run: mkdir -p ${{ env.pitest_dest }}
 
@@ -323,14 +367,19 @@ jobs:
         check_artifacts: true
         if_no_artifact_found: error
 
-    - name: d-pitest Deploy Pitest (PR ${{ matrix.value.number }}) 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
-      with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: ${{ env.pitest_dest }} # The folder where we put the files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: prs/${{ matrix.value.number }}/pitest # The folder that we serve our files from
 
+    - name: d-pitest Deploy Pitest (PR ${{ matrix.value.number }}) 🚀   
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
+      with:
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder:${{ env.pitest_dest }} # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: prs/${{ matrix.value.number }}/pitest # The folder that we serve our files from
 
     - name: e-coverage Make directory in case it doesn't exist
       run: mkdir -p ${{ env.coverage_dest }}
@@ -345,14 +394,19 @@ jobs:
         check_artifacts: true
         if_no_artifact_found: error
 
-    - name: e-coverage Deploy Coverage (PR ${{ matrix.value.number }}) 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+ 
+    - name: e-coverage Deploy Coverage (PR ${{ matrix.value.number }}) 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: ${{ env.coverage_dest }} # The folder where we put the files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: prs/${{ matrix.value.number }}/coverage # The folder that we serve our files from
-
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: ${{ env.coverage_dest }} # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: prs/${{ matrix.value.number }}/coverage # The folder that we serve our files from
     - name: f-stryker Make directory in case it doesn't exist
       run: mkdir -p ${{ env.stryker_dest }}
 
@@ -366,10 +420,16 @@ jobs:
         check_artifacts: true
         if_no_artifact_found: error
 
-    - name: f-stryker Deploy Stryker (PR ${{ matrix.value.number }}) 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+
+    - name: f-stryker Deploy Stryker (PR ${{ matrix.value.number }}) 🚀   
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: ${{ env.stryker_dest }} # The folder where we put the files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: prs/${{ matrix.value.number }}/stryker # The folder that we serve our files from
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder:  ${{ env.stryker_dest }} # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: prs/${{ matrix.value.number }}/stryker # The folder that we serve our files from

--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -97,11 +97,15 @@ jobs:
         echo "prefix=${prefix}"
         echo "prefix=${prefix}" >> "$GITHUB_ENV"
 
-    - name: Deploy 🚀
+    - name: Deploy 🚀    
       if: always() # always upload artifacts, even if tests fail
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: target/pit-reports # The folder where the files we want to publish are located
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: ${{env.prefix}}pitest # The folder that we serve our files from
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: target/pit-reports # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder:${{env.prefix}}pitest # The folder that we serve our files from

--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -108,4 +108,4 @@ jobs:
           branch: gh-pages # The branch the action should deploy to.
           folder: target/pit-reports # The folder where mvn puts the files
           clean: true # Automatically remove deleted files from the deploy branch
-          target-folder:${{env.prefix}}pitest # The folder that we serve our files from
+          target-folder: ${{env.prefix}}pitest # The folder that we serve our files from

--- a/.github/workflows/14-backend-pitest.yml
+++ b/.github/workflows/14-backend-pitest.yml
@@ -86,11 +86,15 @@ jobs:
         echo "prefix=${prefix}"
         echo "prefix=${prefix}" >> "$GITHUB_ENV"
 
-    - name: Deploy 🚀
+    - name: Deploy 🚀    
       if: always() # always upload artifacts, even if tests fail
-      uses: JamesIves/github-pages-deploy-action@v4
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: target/pit-reports # The folder where the files we want to publish are located
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: ${{env.prefix}}pitest # The folder that we serve our files from
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: target/pit-reports # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: ${{env.prefix}}pitest # The folder that we serve our files from

--- a/.github/workflows/53-chromatic-main-branch.yml
+++ b/.github/workflows/53-chromatic-main-branch.yml
@@ -55,13 +55,17 @@ jobs:
           mkdir -p chromatic_static
           echo "<meta http-equiv=refresh content=0;url=${{steps.run_chromatic.outputs.storybookUrl}}>" > chromatic_static/index.html
 
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Deploy 🚀    
+        if: always() # always upload artifacts, even if tests fail
+        uses: Wandalen/wretry.action@master
         with:
+          action: JamesIves/github-pages-deploy-action@v4
+          attempt_limit: 3
+          attempt_delay: 5000
+          with: |
             branch: gh-pages # The branch the action should deploy to.
-            folder: frontend/chromatic_static # source
+            folder: frontend/chromatic_static # The folder where mvn puts the files
             clean: true # Automatically remove deleted files from the deploy branch
-            target-folder: chromatic # destination 
-       
-     
-   
+            target-folder: chromatic # The folder that we serve our files from       
+      
+    

--- a/.github/workflows/56-javadoc-main-branch.yml
+++ b/.github/workflows/56-javadoc-main-branch.yml
@@ -38,12 +38,16 @@ jobs:
     - name: Build javadoc
       run: mvn -DskipTests javadoc:javadoc
 
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+    - name: Deploy 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: target/site/apidocs # The folder where the javadoc files are located
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: javadoc # The folder that we serve our javadoc files from
-
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: target/site/apidocs # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: javadoc # The folder that we serve our files from
   

--- a/.github/workflows/58-javadoc-pr.yml
+++ b/.github/workflows/58-javadoc-pr.yml
@@ -82,13 +82,17 @@ jobs:
     - name: Build javadoc
       run: mvn -DskipTests javadoc:javadoc
  
-    - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@v4
+    - name: Deploy 🚀    
+      if: always() # always upload artifacts, even if tests fail
+      uses: Wandalen/wretry.action@master
       with:
-        branch: gh-pages # The branch the action should deploy to.
-        folder: target/site/apidocs # The folder where mvn javadoc:javadoc outputs the javadoc files
-        clean: true # Automatically remove deleted files from the deploy branch
-        target-folder: prs/${{ needs.get-pr-num.outputs.pr_number }}/javadoc # The folder that we serve our javadoc files from 
-  
+        action: JamesIves/github-pages-deploy-action@v4
+        attempt_limit: 3
+        attempt_delay: 5000
+        with: |
+          branch: gh-pages # The branch the action should deploy to.
+          folder: target/site/apidocs # The folder where mvn puts the files
+          clean: true # Automatically remove deleted files from the deploy branch
+          target-folder: prs/${{ needs.get-pr-num.outputs.pr_number }}/javadoc # The folder that we serve our files from  
   
  


### PR DESCRIPTION
Closes #27 

In this PR, we wrap these Deploy steps in a Github Action that will repeat the step several times before failing after a delay. Any of the workflows that look something like  [OLD CODE]
- name: Deploy 🚀
      uses: JamesIves/github-pages-deploy-action@v4
      with:
        branch: gh-pages # The branch the action should deploy to.
        folder: target/site/jacoco # The folder where mvn puts the files
        clean: true # Automatically remove deleted files from the deploy branch
        target-folder: ${{env.prefix}}jacoco # The folder that we serve our files from

was changed into something that looks like  [NEW CODE]
   - name: Deploy 🚀    
      if: always() # always upload artifacts, even if tests fail
      uses: Wandalen/wretry.action@master
      with:
        action: JamesIves/github-pages-deploy-action@v4
        attempt_limit: 3
        attempt_delay: 5000
        with: |
          branch: gh-pages # The branch the action should deploy to.
          folder: target/site/jacoco # The folder where mvn puts the files
          clean: true # Automatically remove deleted files from the deploy branch
          target-folder: ${{env.prefix}}jacoco # The folder that we serve our files from