### PR TITLE
rg - add moderator role backend

### DIFF
--- a/src/main/java/edu/ucsb/cs156/dining/config/SecurityConfig.java
+++ b/src/main/java/edu/ucsb/cs156/dining/config/SecurityConfig.java
@@ -38,7 +38,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
 
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -122,6 +121,10 @@ public class SecurityConfig {
           if (email.endsWith("@ucsb.edu")) {
             mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_MEMBER"));
           }
+
+          if (getModerator(email)) {
+            mappedAuthorities.add(new SimpleGrantedAuthority("ROLE_MODERATOR"));
+          }
         }
 
       });
@@ -145,6 +148,20 @@ public class SecurityConfig {
     Optional<User> u = userRepository.findByEmail(email);
     return u.isPresent() && u.get().getAdmin();
   }
+
+  /**
+   * This method checks if the given email belongs to an moderator user either from a
+   * predefined
+   * list or by querying the user repository.
+   * 
+   * @param email email address of the user
+   * @return whether the user with the given email is a moderator
+   */
+  public boolean getModerator(String email) {
+    Optional<User> u = userRepository.findByEmail(email);
+    return u.isPresent() && u.get().getModerator();
+  }
+
 }
 
 final class SpaCsrfTokenRequestHandler extends CsrfTokenRequestAttributeHandler {

--- a/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/ReviewController.java
@@ -206,7 +206,7 @@ public class ReviewController extends ApiController {
     }
 
     @Operation(summary = "Moderate a review")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_MODERATOR')")
     @PutMapping("/moderate")
     public Review moderateReview(@Parameter Long id, @Parameter ModerationStatus status, @Parameter String moderatorComments) {
         Review review = reviewRepository.findById(id).orElseThrow(
@@ -221,7 +221,7 @@ public class ReviewController extends ApiController {
     }
 
     @Operation(summary = "See reviews that need moderation")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PreAuthorize("hasRole('ROLE_ADMIN') or hasRole('ROLE_MODERATOR')")
     @GetMapping("/needsmoderation")
     public Iterable<Review> needsmoderation() {
         Iterable<Review> reviewsList = reviewRepository.findByStatus(ModerationStatus.AWAITING_REVIEW);

--- a/src/main/java/edu/ucsb/cs156/dining/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/dining/entities/User.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.dining.entities;
 
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.ser.std.StdKeySerializers.Default;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import edu.ucsb.cs156.dining.statuses.ModerationStatus;
 import jakarta.persistence.*;
@@ -37,12 +38,16 @@ public class User {
  private boolean emailVerified;
  private String locale;
  private String hostedDomain;
- private boolean admin;
  private String alias;
  private String proposedAlias;
  @Enumerated(EnumType.STRING)
  private ModerationStatus status;
  private LocalDate dateApproved;
+ 
+ @Builder.Default
+ private boolean admin=false;
+ @Builder.Default
+ private boolean moderator=false;
 
  @ToString.Exclude
  @OneToMany(mappedBy="reviewer")

--- a/src/main/java/edu/ucsb/cs156/dining/interceptors/RoleInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/dining/interceptors/RoleInterceptor.java
@@ -1,0 +1,66 @@
+package edu.ucsb.cs156.dining.interceptors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import edu.ucsb.cs156.dining.repositories.UserRepository;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Optional;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import edu.ucsb.cs156.dining.entities.User;
+
+@Slf4j
+@Component
+public class RoleInterceptor implements HandlerInterceptor {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication.getClass() == OAuth2AuthenticationToken.class) {
+            OAuth2User principal = ((OAuth2AuthenticationToken) authentication).getPrincipal();
+            String email = principal.getAttribute("email");
+            Optional<User> optionalUser = userRepository.findByEmail(email);
+            if (optionalUser.isPresent()) {
+                User user = optionalUser.get();
+                Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+                Set<GrantedAuthority> revisedAuthorities = authorities.stream().filter(
+                        grantedAuth -> !grantedAuth.getAuthority().equals("ROLE_ADMIN")
+                                    && !grantedAuth.getAuthority().equals("ROLE_MODERATOR"))
+                        .collect(Collectors.toSet());
+                if (user.getAdmin()) {
+                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+                }
+                if (user.getModerator()) {
+                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_MODERATOR"));
+                }
+                Authentication newAuth = new OAuth2AuthenticationToken(principal, revisedAuthorities,
+                        (((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()));
+                SecurityContextHolder.getContext().setAuthentication(newAuth);
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/dining/interceptors/RoleInterceptorConfig.java
+++ b/src/main/java/edu/ucsb/cs156/dining/interceptors/RoleInterceptorConfig.java
@@ -1,0 +1,17 @@
+package edu.ucsb.cs156.dining.interceptors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Component
+public class RoleInterceptorConfig implements WebMvcConfigurer {
+    @Autowired
+    RoleInterceptor roleAdminModeratorInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(roleAdminModeratorInterceptor);
+    }
+}

--- a/src/main/resources/db/migration/changes/Users001-AddMod.json
+++ b/src/main/resources/db/migration/changes/Users001-AddMod.json
@@ -1,0 +1,39 @@
+{ "databaseChangeLog": [
+  {
+    "changeSet": {
+      "id": "Users001-AddMod",
+      "author": "RiyaGupta1234",
+      "preConditions": [
+        {
+          "onFail": "MARK_RAN"
+        },
+        {
+          "not": {
+            "columnExists": {
+              "tableName": "USERS",
+              "columnName": "MODERATOR"
+            }
+          }
+        }
+      ],
+      "changes": [
+        {
+          "addColumn": {
+            "columns": [
+              {
+                "column": {
+                  "constraints": {
+                    "nullable": false
+                  },
+                  "name": "MODERATOR",
+                  "type": "BOOLEAN"
+                }
+              }
+            ],
+            "tableName": "USERS"
+          }
+        }
+      ]
+    }
+  }
+]}

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/ReviewControllerTests.java
@@ -156,7 +156,7 @@ public class ReviewControllerTests extends ControllerTestCase {
                 .andExpect(status().isOk())
                 .andReturn();
 
-        String jsonReview = mapper.writeValueAsString(reviewReturn);
+                String jsonReview = mapper.writeValueAsString(reviewReturn);
 
         // Assert
         verify(reviewRepository).save(any(Review.class));
@@ -185,21 +185,21 @@ public class ReviewControllerTests extends ControllerTestCase {
                 .andExpect(status().isBadRequest());
     }
 
-    // Test valid input at boundaries
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void postReview_ShouldAcceptRatingAtBoundaries() throws Exception {
-        // Lower boundary test
-        mockMvc.perform(
-                        post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
-                                .with(csrf()))
-                .andExpect(status().isOk());
-        // Lower boundary test
-        mockMvc.perform(
-                        post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=5&dateItemServed=2021-12-12T08:08:08")
-                                .with(csrf()))
-                .andExpect(status().isOk());
-    }
+        // Test valid input at boundaries
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void postReview_ShouldAcceptRatingAtBoundaries() throws Exception {
+                // Lower boundary test
+                mockMvc.perform(
+                                post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=1&dateItemServed=2021-12-12T08:08:08")
+                                                .with(csrf()))
+                                .andExpect(status().isOk());
+                // Lower boundary test
+                mockMvc.perform(
+                                post("/api/reviews/post?itemId=1&reviewerComments=Worst flavor ever.&itemsStars=5&dateItemServed=2021-12-12T08:08:08")
+                                                .with(csrf()))
+                                .andExpect(status().isOk());
+        }
 
 
     @WithMockUser(roles = {"USER"})
@@ -435,82 +435,81 @@ public class ReviewControllerTests extends ControllerTestCase {
                 .id(0L)
                 .build();
 
-        ArrayList<Review> reviews = new ArrayList<>();
-        reviews.addAll(Arrays.asList(review1, review2, review3));
+                ArrayList<Review> reviews = new ArrayList<>();
+                reviews.addAll(Arrays.asList(review1, review2, review3));
 
-        when(reviewRepository.findAll()).thenReturn(reviews);
-        // Act
-        MvcResult response = mockMvc.perform(get("/api/reviews/all"))
-                .andExpect(status().is(200)).andReturn();
+                when(reviewRepository.findAll()).thenReturn(reviews);
+                // Act
+                MvcResult response = mockMvc.perform(get("/api/reviews/all"))
+                                .andExpect(status().is(200)).andReturn();
 
-        // assert
-        verify(reviewRepository, times(1)).findAll();
-        String expectedJson = mapper.writeValueAsString(reviews);
-        String responseString = response.getResponse().getContentAsString();
-        assertEquals(expectedJson, responseString);
-    }
+                // assert
+                verify(reviewRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(reviews);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
 
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void a_logged_in_user_can_get_own_reviews_list() throws Exception {
+                // Arrange
+                User user1 = currentUserService.getUser();
+                User user2 = User.builder().id(2L).build();
 
-    @WithMockUser(roles = {"USER"})
-    @Test
-    public void a_logged_in_user_can_get_own_reviews_list() throws Exception {
-        // Arrange
-        User user1 = currentUserService.getUser();
-        User user2 = User.builder().id(2L).build();
+                MenuItem menuItem1 = MenuItem.builder().id(1L).build();
+                MenuItem menuItem2 = MenuItem.builder().id(313L).build();
 
-        MenuItem menuItem1 = MenuItem.builder().id(1L).build();
-        MenuItem menuItem2 = MenuItem.builder().id(313L).build();
+                Review review1 = Review.builder()
+                                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
+                                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
+                                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
+                                .reviewer(user1)
+                                .status(ModerationStatus.AWAITING_REVIEW)
+                                .item(menuItem1)
+                                .id(1L)
+                                .build();
 
-        Review review1 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 7, 1, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 12, 47))
-                .dateItemServed(LocalDateTime.of(2021, 12, 12, 1, 3))
-                .reviewer(user1)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(1L)
-                .build();
+                Review review2 = Review.builder()
+                                .dateCreated(LocalDateTime.of(2024, 4, 28, 1, 47))
+                                .dateEdited(LocalDateTime.of(2024, 7, 2, 6, 47))
+                                .dateItemServed(LocalDateTime.of(2022, 2, 6, 8, 8))
+                                .reviewer(user2)
+                                .status(ModerationStatus.AWAITING_REVIEW)
+                                .item(menuItem1)
+                                .id(2L)
+                                .build();
 
-        Review review2 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 4, 28, 1, 47))
-                .dateEdited(LocalDateTime.of(2024, 7, 2, 6, 47))
-                .dateItemServed(LocalDateTime.of(2022, 2, 6, 8, 8))
-                .reviewer(user2)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem1)
-                .id(2L)
-                .build();
+                Review review3 = Review.builder()
+                                .dateCreated(LocalDateTime.of(2024, 2, 17, 2, 47))
+                                .dateEdited(LocalDateTime.of(2024, 12, 15, 04, 26))
+                                .dateItemServed(LocalDateTime.of(2023, 1, 7, 3, 8))
+                                .reviewer(user2)
+                                .status(ModerationStatus.AWAITING_REVIEW)
+                                .item(menuItem2)
+                                .id(3L)
+                                .build();
 
-        Review review3 = Review.builder()
-                .dateCreated(LocalDateTime.of(2024, 2, 17, 2, 47))
-                .dateEdited(LocalDateTime.of(2024, 12, 15, 04, 26))
-                .dateItemServed(LocalDateTime.of(2023, 1, 7, 3, 8))
-                .reviewer(user2)
-                .status(ModerationStatus.AWAITING_REVIEW)
-                .item(menuItem2)
-                .id(3L)
-                .build();
+                ArrayList<Review> reviews = new ArrayList<>();
+                ArrayList<Review> valid_reviews = new ArrayList<>();
+                valid_reviews.addAll(Arrays.asList(review1));
+                reviews.addAll(Arrays.asList(review1, review2, review3));
+                when(reviewRepository.findByReviewer(eq(user1))).thenReturn(valid_reviews);
 
-        ArrayList<Review> reviews = new ArrayList<>();
-        ArrayList<Review> valid_reviews = new ArrayList<>();
-        valid_reviews.addAll(Arrays.asList(review1));
-        reviews.addAll(Arrays.asList(review1, review2, review3));
-        when(reviewRepository.findByReviewer(eq(user1))).thenReturn(valid_reviews);
+                // Act
+                MvcResult response = mockMvc.perform(
+                                get("/api/reviews/userReviews")
+                                                .with(csrf()))
+                                .andExpect(status().isOk())
+                                .andReturn();
 
-        // Act
-        MvcResult response = mockMvc.perform(
-                        get("/api/reviews/userReviews")
-                                .with(csrf()))
-                .andExpect(status().isOk())
-                .andReturn();
+                // assert
+                verify(reviewRepository, times(1)).findByReviewer(eq(user1));
+                String expectedJson = mapper.writeValueAsString(valid_reviews);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
 
-        // assert
-        verify(reviewRepository, times(1)).findByReviewer(eq(user1));
-        String expectedJson = mapper.writeValueAsString(valid_reviews);
-        String responseString = response.getResponse().getContentAsString();
-        assertEquals(expectedJson, responseString);
-
-    }
+        }
 
 
     @WithMockUser(roles = {"USER"})
@@ -982,7 +981,7 @@ public class ReviewControllerTests extends ControllerTestCase {
         assertEquals("Review with id 1 not found", json.get("message"));
     }
 
-    @WithMockUser(roles = {"ADMIN"})
+    @WithMockUser(roles = {"ADMIN", "MODERATOR"})
     @Test
     public void admin_can_moderate_a_review() throws Exception{
         User user1 = User.builder().id(2L).build();
@@ -1027,7 +1026,7 @@ public class ReviewControllerTests extends ControllerTestCase {
         assertEquals(jsonExpected, jsonResponse);
     }
 
-    @WithMockUser(roles = {"ADMIN"})
+    @WithMockUser(roles = {"ADMIN", "MODERATOR"})
     @Test
     public void nonexistent_cannot_approve() throws Exception{
         when(reviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
@@ -1042,7 +1041,7 @@ public class ReviewControllerTests extends ControllerTestCase {
         assertEquals("Review with id 1 not found", json.get("message"));
     }
 
-    @WithMockUser(roles = {"ADMIN"})
+    @WithMockUser(roles = {"ADMIN", "MODERATOR"})
     @Test
     public void get_needs_moderation_returns_moderation_needed() throws Exception{
         User user1 = User.builder().id(2L).build();

--- a/src/test/java/edu/ucsb/cs156/dining/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/controllers/UsersControllerTests.java
@@ -93,6 +93,7 @@ public class UsersControllerTests extends ControllerTestCase {
             .locale("")
             .hostedDomain("example.org")
             .admin(true)
+            .moderator(false)
             .alias("Anonymous User") 
             .proposedAlias("Chipotle")
             .status(ModerationStatus.AWAITING_REVIEW)

--- a/src/test/java/edu/ucsb/cs156/dining/interceptors/RoleInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/dining/interceptors/RoleInterceptorTests.java
@@ -1,0 +1,213 @@
+package edu.ucsb.cs156.dining.interceptors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import edu.ucsb.cs156.dining.ControllerTestCase;
+import edu.ucsb.cs156.dining.entities.User;
+import edu.ucsb.cs156.dining.repositories.UserRepository;
+import edu.ucsb.cs156.dining.statuses.ModerationStatus;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class RoleInterceptorTests extends ControllerTestCase {
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Autowired
+    private RequestMappingHandlerMapping mapping;
+
+    @BeforeEach
+    public void mockLogin() {
+        HashMap<String, Object> values = new HashMap<>();
+
+        values.put("email", "cgaucho@ucsb.edu");
+        values.put("googleSub", "googleSub");
+        values.put("pictureUrl", "pictureUrl");
+        values.put("fullName", "Joe Gaucho");
+        values.put("givenName", "Joe");
+        values.put("familyName", "Gaucho");
+        values.put("emailVerified", true);
+        values.put("locale", "en");
+        values.put("hostedDomain", "ucsb.edu");
+        values.put("alias", "joeg");
+        values.put("proposedAlias", "joeprop");
+        values.put("status", "APPROVED");
+        values.put("dateApproved", "2025-05-18");
+
+        Set<GrantedAuthority> credentials = new HashSet<>();
+        credentials.add(new SimpleGrantedAuthority("ROLE_USER"));
+        credentials.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
+        credentials.add(new SimpleGrantedAuthority("ROLE_MODERATOR"));
+
+        OAuth2User user = new DefaultOAuth2User(credentials, values, "email");
+        Authentication auth = new OAuth2AuthenticationToken(user, credentials, "google");
+        SecurityContextHolder.setContext(SecurityContextHolder.createEmptyContext());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @Test
+    public void RoleInterceptorIsPresent() throws Exception {
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+        HandlerExecutionChain chain = mapping.getHandler(request);
+
+        assert chain != null;
+        Optional<HandlerInterceptor> RoleInterceptor = chain.getInterceptorList()
+                .stream()
+                .filter(RoleInterceptor.class::isInstance)
+                .findFirst();
+
+        assertTrue(RoleInterceptor.isPresent());
+    }
+
+    @Test
+    public void updates_admin_role_when_user_admin_false() throws Exception {
+        User user = User.builder()
+                .id(1L)
+                .email("cgaucho@ucsb.edu")
+                .admin(false)
+                .moderator(true)
+                .build();
+        when(userRepository.findByEmail("cgaucho@ucsb.edu")).thenReturn(Optional.of(user));
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+        HandlerExecutionChain chain = mapping.getHandler(request);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assert chain != null;
+        Optional<HandlerInterceptor> RoleInterceptor = chain.getInterceptorList()
+                .stream()
+                .filter(RoleInterceptor.class::isInstance)
+                .findFirst();
+
+        assertTrue(RoleInterceptor.isPresent());
+
+        RoleInterceptor.get().preHandle(request, response, chain.getHandler());
+
+        verify(userRepository, times(1)).findByEmail("cgaucho@ucsb.edu");
+
+        Collection<? extends GrantedAuthority> authorities = SecurityContextHolder.getContext()
+                .getAuthentication().getAuthorities();
+
+        boolean role_admin = authorities.stream()
+                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_ADMIN"));
+        boolean role_moderator = authorities.stream()
+                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_MODERATOR"));
+        boolean role_user = authorities.stream()
+                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_USER"));
+        assertFalse(role_admin, "ROLE_ADMIN should not be in roles list");
+        assertTrue(role_moderator, "ROLE_MODERATOR should be in roles list");
+        assertTrue(role_user, "ROLE_USER should be in roles list");
+    }
+
+    @Test
+    public void updates_moderator_role_when_user_moderator_false() throws Exception {
+        User user = User.builder()
+                .id(1L)
+                .email("cgaucho@ucsb.edu")
+                .admin(true)
+                .moderator(false)
+                .build();
+        when(userRepository.findByEmail("cgaucho@ucsb.edu")).thenReturn(Optional.of(user));
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+        HandlerExecutionChain chain = mapping.getHandler(request);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assert chain != null;
+        Optional<HandlerInterceptor> RoleInterceptor = chain.getInterceptorList()
+                .stream()
+                .filter(RoleInterceptor.class::isInstance)
+                .findFirst();
+
+        assertTrue(RoleInterceptor.isPresent());
+
+        RoleInterceptor.get().preHandle(request, response, chain.getHandler());
+
+        verify(userRepository, times(1)).findByEmail("cgaucho@ucsb.edu");
+
+        Collection<? extends GrantedAuthority> authorities = SecurityContextHolder.getContext()
+                .getAuthentication().getAuthorities();
+
+        boolean role_admin = authorities.stream()
+                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_ADMIN"));
+        boolean role_moderator = authorities.stream()
+                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_MODERATOR"));
+        boolean role_user = authorities.stream()
+                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_USER"));
+        assertTrue(role_admin, "ROLE_ADMIN should be in roles list");
+        assertFalse(role_moderator, "ROLE_MODERATOR should not be in roles list");
+        assertTrue(role_user, "ROLE_USER should be in roles list");
+    }
+
+    @Test
+    public void updates_nothing_when_user_not_present() throws Exception {
+        User user = User.builder()
+                .email("cgaucho2@ucsb.edu")
+                .id(15L)
+                .admin(false)
+                .moderator(false)
+                .build();
+        when(userRepository.findByEmail("cgaucho2@ucsb.edu")).thenReturn(Optional.of(user));
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+        HandlerExecutionChain chain = mapping.getHandler(request);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assert chain != null;
+        Optional<HandlerInterceptor> RoleInterceptor = chain.getInterceptorList()
+                .stream()
+                .filter(RoleInterceptor.class::isInstance)
+                .findFirst();
+
+        assertTrue(RoleInterceptor.isPresent());
+
+        RoleInterceptor.get().preHandle(request, response, chain.getHandler());
+
+        verify(userRepository, times(1)).findByEmail("cgaucho@ucsb.edu");
+
+        Collection<? extends GrantedAuthority> authorities = SecurityContextHolder.getContext()
+                .getAuthentication().getAuthorities();
+
+        boolean role_admin = authorities.stream()
+                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_ADMIN"));
+        boolean role_moderator = authorities.stream()
+                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_MODERATOR"));
+        boolean role_user = authorities.stream()
+                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_USER"));
+        assertTrue(role_admin, "ROLE_ADMIN should be in roles list");
+        assertTrue(role_moderator, "ROLE_MODERATOR should be in roles list");
+        assertTrue(role_user, "ROLE_USER should be in roles list");
+    }
+}

--- a/src/test/java/edu/ucsb/cs156/dining/testconfig/MockCurrentUserServiceImpl.java
+++ b/src/test/java/edu/ucsb/cs156/dining/testconfig/MockCurrentUserServiceImpl.java
@@ -27,6 +27,7 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
     String locale="";
     String hostedDomain="example.org";
     boolean admin=false;
+    boolean moderator=false;
 
     org.springframework.security.core.userdetails.User user = null;
 
@@ -43,6 +44,7 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
       locale="";
       hostedDomain="example.org";
       admin= securityContext.getAuthentication().getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"));
+      moderator= securityContext.getAuthentication().getAuthorities().contains(new SimpleGrantedAuthority("ROLE_MODERATOR"));
     }
 
     User u = User.builder()
@@ -56,6 +58,7 @@ public class MockCurrentUserServiceImpl extends CurrentUserServiceImpl {
     .locale(locale)
     .hostedDomain(hostedDomain)
     .admin(admin)
+    .moderator(moderator)
     .id(1L)
     .build();
     


### PR DESCRIPTION
Closes #1 

This PR adds the moderator role to the backend. In the screenshot below, we can see that the moderator field has been added. Log in as an admin, go to swagger, and get a list of all users (under user info, admin only -- /api/users/get). You can see that after the admin field, there is also the moderator field, which has just been added.

The dokku deployment can be found here: https://proj-dining-s25-06-riyagupta1234.dokku-06.cs.ucsb.edu

<img width="1470" alt="Screenshot 2025-05-17 at 10 52 52 PM" src="https://github.com/user-attachments/assets/a0ac6483-9c5e-4caa-8cef-2ee4aa43fcdc" />

And you can see the moderator tab from the frontend
<img width="823" alt="Screenshot 2025-05-17 at 11 16 14 PM" src="https://github.com/user-attachments/assets/f9f0b544-dbc7-44b2-b563-3d37096b4b51" />
